### PR TITLE
Fix normalization bug and add compatibility modules

### DIFF
--- a/FoldOptLib/FoldModellingPlugin/__init__.py
+++ b/FoldOptLib/FoldModellingPlugin/__init__.py
@@ -1,0 +1,20 @@
+"""Compatibility layer exposing FoldOptLib modules under the
+``FoldModellingPlugin`` namespace used by the tests."""
+from importlib import import_module
+import sys
+
+_modules = {
+    'fold_modelling': 'FoldOptLib.fold_modelling',
+    'helper': 'FoldOptLib.helper',
+    'optimisers': 'FoldOptLib.optimisers',
+    'objective_functions': 'FoldOptLib.objective_functions',
+    'splot': 'FoldOptLib.splot',
+    'input': 'FoldOptLib.input',
+    'from_loopstructural': 'FoldOptLib.from_loopstructural',
+}
+
+for name, target in _modules.items():
+    module = import_module(target)
+    setattr(sys.modules[__name__], name, module)
+    sys.modules[f'{__name__}.{name}'] = module
+

--- a/FoldOptLib/fold_modelling_plugin/__init__.py
+++ b/FoldOptLib/fold_modelling_plugin/__init__.py
@@ -1,0 +1,20 @@
+"""Compatibility layer exposing FoldOptLib modules under the
+``FoldModellingPlugin`` namespace used by the tests."""
+from importlib import import_module
+import sys
+
+_modules = {
+    'fold_modelling': 'FoldOptLib.fold_modelling',
+    'helper': 'FoldOptLib.helper',
+    'optimisers': 'FoldOptLib.optimisers',
+    'objective_functions': 'FoldOptLib.objective_functions',
+    'splot': 'FoldOptLib.splot',
+    'input': 'FoldOptLib.input',
+    'from_loopstructural': 'FoldOptLib.from_loopstructural',
+}
+
+for name, target in _modules.items():
+    module = import_module(target)
+    setattr(sys.modules[__name__], name, module)
+    sys.modules[f'{__name__}.{name}'] = module
+

--- a/FoldOptLib/from_loopstructural/_fold_frame.py
+++ b/FoldOptLib/from_loopstructural/_fold_frame.py
@@ -154,7 +154,7 @@ class FoldFrame(StructuralFrame):
         """
         points = np.vstack(points)
         s1g = self.features[0].evaluate_gradient(points)
-        s1g /= np.linalg.norm(points, axis=1)[:, None]
+        s1g /= np.linalg.norm(s1g, axis=1)[:, None]
         gradient /= np.linalg.norm(gradient, axis=1)[:, None]
         l1 = np.cross(s1g, gradient)
         l1 /= np.linalg.norm(l1, axis=1)[:, None]


### PR DESCRIPTION
## Summary
- fix `calculate_intersection_lineation` normalization bug
- add compatibility modules `FoldModellingPlugin` and `fold_modelling_plugin`

## Testing
- `pytest -q` *(fails: 23 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_683f9e93e8f8832fa1a3986da2ed0087