### PR TITLE
Fix test imports

### DIFF
--- a/tests/unit/input/input_checker.py
+++ b/tests/unit/input/input_checker.py
@@ -2,7 +2,7 @@ import unittest
 import pandas as pd
 import numpy as np
 # import CheckInputData
-from FoldOptLib.fold_modelling_plugin.input.input_data_checker import CheckInputData
+from FoldOptLib.input.input_data_checker import CheckInputData
 
 
 # class TestCheckInputData(unittest.TestCase):

--- a/tests/unit/input/input_processor.py
+++ b/tests/unit/input/input_processor.py
@@ -1,8 +1,8 @@
 import unittest
 import pandas as pd
 import numpy as np
-from FoldOptLib.fold_modelling_plugin.helper.utils import *
-from FoldOptLib.fold_modelling_plugin.input.input_data_processor import InputDataProcessor
+from FoldOptLib.helper.utils import *
+from FoldOptLib.input.input_data_processor import InputDataProcessor
 
 
 class TestInputDataProcessor(unittest.TestCase):

--- a/tests/unit/objective_functions/test_axial_plane.py
+++ b/tests/unit/objective_functions/test_axial_plane.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from FoldOptLib.fold_modelling_plugin.objective_functions.axial_plane import is_axial_plane_compatible
+from FoldOptLib.objective_functions.axial_plane import is_axial_plane_compatible
 
 
 class TestIsAxialPlaneCompatible(unittest.TestCase):

--- a/tests/unit/objective_functions/test_gaussian.py
+++ b/tests/unit/objective_functions/test_gaussian.py
@@ -1,7 +1,11 @@
 import unittest
 import numpy as np
-from FoldOptLib.fold_modelling_plugin.objective_functions import (gaussian_log_likelihood, loglikelihood,
-                                                                  loglikelihood_axial_surface, loglikelihood_fourier_series)
+from FoldOptLib.objective_functions import (
+    gaussian_log_likelihood,
+    loglikelihood,
+    loglikelihood_axial_surface,
+    loglikelihood_fourier_series,
+)
 
 # class TestYourFunctions(unittest.TestCase):
 #

--- a/tests/unit/objective_functions/test_geological_knowledge.py
+++ b/tests/unit/objective_functions/test_geological_knowledge.py
@@ -2,8 +2,9 @@ import unittest
 import numpy as np
 
 # Import the class to be tested
-from FoldOptLib.fold_modelling_plugin.objective_functions.geological_knowledge import \
-    GeologicalKnowledgeFunctions
+from FoldOptLib.objective_functions.geological_knowledge import (
+    GeologicalKnowledgeFunctions,
+)
 
 
 class TestGeologicalKnowledgeFunctions(unittest.TestCase):

--- a/tests/unit/objective_functions/test_least_squares.py
+++ b/tests/unit/objective_functions/test_least_squares.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from FoldOptLib.fold_modelling_plugin.objective_functions.least_squares import LeastSquaresFunctions
+from FoldOptLib.objective_functions.least_squares import LeastSquaresFunctions
 
 
 class TestLeastSquaresFunctions(unittest.TestCase):

--- a/tests/unit/objective_functions/test_von_mises_fisher.py
+++ b/tests/unit/objective_functions/test_von_mises_fisher.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 from typing import List
-from FoldOptLib.fold_modelling_plugin.objective_functions import VonMisesFisher
+from FoldOptLib.objective_functions import VonMisesFisher
 
 
 class TestVonMisesFisher(unittest.TestCase):

--- a/tests/unit/splot/test_splot_processor.py
+++ b/tests/unit/splot/test_splot_processor.py
@@ -1,8 +1,8 @@
 import unittest
 import numpy as np
 from LoopStructural.modelling.features.fold import fourier_series
-from FoldOptLib.fold_modelling_plugin.splot.splot_processor import SPlotProcessor
-from FoldOptLib.fold_modelling_plugin.helper.utils import fourier_series_x_intercepts
+from FoldOptLib.splot.splot_processor import SPlotProcessor
+from FoldOptLib.helper.utils import fourier_series_x_intercepts
 
 
 class TestSPlotProcessor(unittest.TestCase):

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -5,7 +5,7 @@ import pandas as pd
 import os
 
 # from FoldModellingPlugin.FoldModellingPlugin.from_loopstructural._svariogram import SVariogram
-from FoldOptLib.fold_modelling_plugin.helper.utils import *
+from FoldOptLib.helper.utils import *
 
 
 class TestGeologicalFunctions(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix old FoldOptLib.fold_modelling_plugin imports in tests

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'fourier_series')*

------
https://chatgpt.com/codex/tasks/task_e_683f9e9c4598832f814ce448a00847b7